### PR TITLE
lint: remove reflected param

### DIFF
--- a/app/controllers/auth/signups_controller.rb
+++ b/app/controllers/auth/signups_controller.rb
@@ -3,7 +3,7 @@
 module Auth
   class SignupsController < CoauthController
     def show
-      render text: "Authentication Failed: #{params.permit(:message)[:message]}"
+      render text: "Authentication Failed"
     end
 
     def create
@@ -53,7 +53,7 @@ module Auth
           head :forbidden
         end
       end
-    end # def create
+    end
 
     protected
 


### PR DESCRIPTION
Removes a reflected parameter in the signups controller