### PR TITLE
fix(models/user): user id should be prefixed

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -16,6 +16,7 @@ class User
     country building created_at
   ]}.freeze
 
+  field :id, type: String, primary_key: true, default: -> { "user-#{::NoBrainer::Document::PrimaryKey::Generator.generate}" }
   field :name, type: String
   field :nickname, type: String
   field :email, type: String, index: true


### PR DESCRIPTION
all existing user entries across most clients will be lacking this prefix as auth will have generated the model