### PR TITLE
fix(set_continue): same_site cookie option for use in iframes

### DIFF
--- a/app/controllers/auth/coauth_controller.rb
+++ b/app/controllers/auth/coauth_controller.rb
@@ -81,7 +81,8 @@ module Auth
         value: path,
         httponly: true,
         secure: USE_SSL,
-        path: "/auth" # only sent to calls at this path
+        same_site: :none,
+        path: "/auth", # only sent to calls at this path
       }
       cookies.encrypted[:continue] = value
     end

--- a/app/controllers/auth/coauth_controller.rb
+++ b/app/controllers/auth/coauth_controller.rb
@@ -82,7 +82,7 @@ module Auth
         httponly: true,
         secure: USE_SSL,
         same_site: :none,
-        path: "/auth", # only sent to calls at this path
+        path: "/auth" # only sent to calls at this path
       }
       cookies.encrypted[:continue] = value
     end


### PR DESCRIPTION
allows embedded applications to authenticate properly (redirecting to the correct path)
