### PR TITLE
fix(dockerfile): Add alpine compat package to fix nokogiri dep on arm…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -43,7 +43,7 @@ WORKDIR $APP_DIR
 ENV BUNDLE_APP_CONFIG="$APP_DIR/.bundle"
 
 # install packages
-ARG PACKAGES="tzdata libxml2 libxslt"
+ARG PACKAGES="tzdata libxml2 libxslt libc6-compat"
 RUN apk update \
     && apk upgrade \
     && apk add --update --no-cache $PACKAGES


### PR DESCRIPTION

**Description of the change**

Add `ld-linux-*` on alpine for `nokogiri` to work properly.

<!-- Describe the scope of your change - i.e. what the change does. -->

**Benefits**
This should enable the image to run correctly on the ARM64 platform as well