### PR TITLE
fix: Add secure flag to the session_store

### DIFF
--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -2,7 +2,9 @@
 
 require "omniauth"
 
-Rails.application.config.session_store :cookie_store, key: "_coauth_session"
+Rails.application.config.session_store :cookie_store,
+  key: "_coauth_session",
+  secure: Rails.env.production?
 
 require_relative "../../app/models/authentication"
 require_relative "../../app/models/authority"


### PR DESCRIPTION
**Description of the change**

Add a secure flag based on the environment to enforce HTTPS for every `_coauth_session` cookie.